### PR TITLE
Fixed bing provider (and jsonp providers in general). Added new option "panOnly"

### DIFF
--- a/src/js/l.control.geosearch.js
+++ b/src/js/l.control.geosearch.js
@@ -34,7 +34,8 @@ L.Control.GeoSearch = L.Control.extend({
             'searchLabel': options.searchLabel || 'search for address...',
             'notFoundMessage' : options.notFoundMessage || 'Sorry, that address could not be found.',
             'messageHideDelay': options.messageHideDelay || 3000,
-            'zoomLevel': options.zoomLevel || 18
+            'zoomLevel': options.zoomLevel || 18,
+            'panOnly': options.panOnly
         };
     },
 
@@ -88,15 +89,20 @@ L.Control.GeoSearch = L.Control.extend({
             else {
                 var url = provider.GetServiceUrl(qry);
 
-                $.getJSON(url, function (data) {
-                    try {
-                        var results = provider.ParseJSON(data);
-                        this._processResults(results);
-                    }
-                    catch (error) {
-                        this._printError(error);
-                    }
-                }.bind(this));
+                $.ajax({
+                    dataType: provider.options.dataType || 'json',
+                    url: url,
+                    jsonp: provider.options.jsonpCallback || 'callback',
+                    success: function (data) {
+                        try {
+                            var results = provider.ParseJSON(data);
+                            this._processResults(results);
+                        }
+                        catch (error) {
+                            this._printError(error);
+                        }
+                    }.bind(this)
+                });
             }
         }
         catch (error) {
@@ -118,7 +124,7 @@ L.Control.GeoSearch = L.Control.extend({
         else
             this._positionMarker.setLatLng([location.Y, location.X]);
 
-        this._map.setView([location.Y, location.X], this._config.zoomLevel, false);
+        this._map.setView([location.Y, location.X], (this._config.panOnly && this._map._zoom) || this._config.zoomLevel, false);
         this._map.fireEvent('geosearch_showlocation', {Location: location});
     },
 

--- a/src/js/l.geosearch.provider.bing.js
+++ b/src/js/l.geosearch.provider.bing.js
@@ -6,7 +6,8 @@
 
 L.GeoSearch.Provider.Bing = L.Class.extend({
     options: {
-
+        dataType: 'jsonp',
+        jsonpCallback: 'jsonp'
     },
 
     initialize: function(options) {
@@ -16,7 +17,7 @@ L.GeoSearch.Provider.Bing = L.Class.extend({
     GetServiceUrl: function (qry) {
         var parameters = L.Util.extend({
             query: qry,
-            jsonp: '?'
+            output: 'json'
         }, this.options);
 
         return 'http://dev.virtualearth.net/REST/v1/Locations'


### PR DESCRIPTION
Changed to geosearch to use jquery.ajax to be able to use jsonp. Tested with Bing and Google.

Fixed Bing provider to use jsonp with correct parameters.

Added option "panOnly": if "true" then the map pans to new location but doesn't change current zoom level.