### PR TITLE
event.preventDefault for searchbox on enter. option "draggable"

### DIFF
--- a/src/js/l.control.geosearch.js
+++ b/src/js/l.control.geosearch.js
@@ -15,7 +15,8 @@ L.GeoSearch.Result = function (x, y, label) {
 L.Control.GeoSearch = L.Control.extend({
     options: {
         position: 'topcenter',
-        showMarker: true
+        showMarker: true,
+        draggable: false
     },
 
     _config: {
@@ -178,11 +179,12 @@ L.Control.GeoSearch = L.Control.extend({
     _showLocation: function (location) {
         if (this.options.showMarker == true) {
             if (typeof this._positionMarker === 'undefined')
-                this._positionMarker = L.marker([location.Y, location.X]).addTo(this._map);
+                this._positionMarker = L.marker(
+                    [location.Y, location.X],
+                    {draggable: this.options.draggable}).addTo(this._map);
             else
                 this._positionMarker.setLatLng([location.Y, location.X]);
         }
-
         this._map.setView([location.Y, location.X], this._config.zoomLevel, false);
         this._map.fireEvent('geosearch_showlocation', {Location: location});
     },

--- a/src/js/l.control.geosearch.js
+++ b/src/js/l.control.geosearch.js
@@ -206,6 +206,8 @@ L.Control.GeoSearch = L.Control.extend({
             queryBox.value = '';
             this._map._container.focus();
         } else if (e.keyCode === enter) {
+            e.preventDefault();
+            e.stopPropagation();
             this.geosearch(queryBox.value);
         }
     }


### PR DESCRIPTION
1) after pressing <enter> in the searchbox, do event.preventDefault and event.stopPropagation to prevent submit forms to be submitted. Fixes #12 

2) add option "draggable", so the marker can be drag/dropped after a search has been done.