### PR TITLE
Sending the marker within the showlocation event

### DIFF
--- a/src/js/l.control.geosearch.js
+++ b/src/js/l.control.geosearch.js
@@ -184,7 +184,7 @@ L.Control.GeoSearch = L.Control.extend({
         }
 
         this._map.setView([location.Y, location.X], this._config.zoomLevel, false);
-        this._map.fireEvent('geosearch_showlocation', {Location: location});
+        this._map.fireEvent('geosearch_showlocation', {Location: location, Marker : ((typeof(this._positionMarker) !== "undefined") ? this._positionMarker : undefined)});
     },
 
     _printError: function(message) {


### PR DESCRIPTION
I think it would be great if the user could locate a place with the geosearch plugin and then modify it with the snap plugin for example (At least it would be great for my needs)

To achieve that, i've just added the marker object to the data sent within the showlocation event.

I know it's not perfect and that it sends undefined if the show marker option is set to false, but I think it's better than sending nothing in that case, because if the rest of the app isn't well coded, the whole script could crash because it tries to access to an value which doesn't exists