### PR TITLE
Retain zoomLevel when centering map

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,8 @@ There are other configurable options like setting the position of the search inp
 new L.Control.GeoSearch({
     provider: new L.GeoSearch.Provider.OpenStreetMap(),
     position: 'topcenter',
-    showMarker: true
+    showMarker: true,
+    retainZoomLevel: false,
 }).addTo(map);
 ````
 

--- a/src/js/l.control.geosearch.js
+++ b/src/js/l.control.geosearch.js
@@ -15,7 +15,8 @@ L.GeoSearch.Result = function (x, y, label) {
 L.Control.GeoSearch = L.Control.extend({
     options: {
         position: 'topcenter',
-        showMarker: true
+        showMarker: true,
+        retainZoomLevel: false
     },
 
     _config: {
@@ -183,7 +184,7 @@ L.Control.GeoSearch = L.Control.extend({
                 this._positionMarker.setLatLng([location.Y, location.X]);
         }
 
-        this._map.setView([location.Y, location.X], this._config.zoomLevel, false);
+        this._map.setView([location.Y, location.X], this._getZoomLevel(), false);
         this._map.fireEvent('geosearch_showlocation', {Location: location});
     },
 
@@ -208,5 +209,13 @@ L.Control.GeoSearch = L.Control.extend({
         } else if (e.keyCode === enter) {
             this.geosearch(queryBox.value);
         }
+    },
+
+    _getZoomLevel: function() {
+        if (! this.options.retainZoomLevel) {
+            return this._config.zoomLevel;
+        }
+        return this._map.zoom;
     }
+
 });


### PR DESCRIPTION
This PR introduces a way to retain the zoom-level of the map you are in. This retaining will of course only be used when the appropriate configuration is set.

You can configure GeoSearch by adding ```retainZoomLevel``` to the config-options like follows:

    new L.Control.GeoSearch({
        provider: new L.GeoSearch.Provider.OpenStreetMap(),
        retainZoomLevel: true,
    }).addTo(map);

Setting ```retainZoomLevel``` to ```true``` will not change the zoom-level the user is currently in when centering the map on the new coordinates. Setting it to ```false``` (which is the default) will keep the current behaviour that changes the zoom-level to a fixed value (by default ```18```)

So Backwards-Compatibility is given, it justs adds the posibility to keep the current zoom-level