### PR TITLE
Support for multiple maps on page

### DIFF
--- a/src/js/l.control.geosearch.js
+++ b/src/js/l.control.geosearch.js
@@ -199,14 +199,13 @@ L.Control.GeoSearch = L.Control.extend({
 
     _onKeyUp: function (e) {
         var esc = 27,
-            enter = 13,
-            queryBox = document.getElementById('leaflet-control-geosearch-qry');
+            enter = 13;
 
         if (e.keyCode === esc) { // escape key detection is unreliable
-            queryBox.value = '';
+            this._searchbox.value = '';
             this._map._container.focus();
         } else if (e.keyCode === enter) {
-            this.geosearch(queryBox.value);
+            this.geosearch(this._searchbox.value);
         }
     }
 });


### PR DESCRIPTION
This minor change avoids the need for querying by element id, since the query input box is already stored on the instance as `this._searchbox`. All the element ids can be removed, but I left them as they are in case people are using ids for styling.