### PR TITLE
Improved OSM support

### DIFF
--- a/src/js/l.control.geosearch.js
+++ b/src/js/l.control.geosearch.js
@@ -6,11 +6,14 @@
 L.GeoSearch = {};
 L.GeoSearch.Provider = {};
 
-L.GeoSearch.Result = function (x, y, label, bounds) {
+L.GeoSearch.Result = function (x, y, label, bounds, details) {
     this.X = x;
     this.Y = y;
     this.Label = label;
     this.bounds = bounds;
+
+    if (details)
+        this.details = details;
 };
 
 L.Control.GeoSearch = L.Control.extend({

--- a/src/js/l.geosearch.provider.openstreetmap.js
+++ b/src/js/l.geosearch.provider.openstreetmap.js
@@ -30,6 +30,9 @@ L.GeoSearch.Provider.OpenStreetMap = L.Class.extend({
                 northEastLatLng = new L.LatLng( boundingBox[1], boundingBox[3] ),
                 southWestLatLng = new L.LatLng( boundingBox[0], boundingBox[2] );
 
+            if (data[i].address)
+                data[i].address.type = data[i].type;
+
             results.push(new L.GeoSearch.Result(
                 data[i].lon,
                 data[i].lat,

--- a/src/js/l.geosearch.provider.openstreetmap.js
+++ b/src/js/l.geosearch.provider.openstreetmap.js
@@ -5,9 +5,7 @@
  */
 
 L.GeoSearch.Provider.OpenStreetMap = L.Class.extend({
-    options: {
-
-    },
+    options: {},
 
     initialize: function(options) {
         options = L.Util.setOptions(this, options);
@@ -25,19 +23,25 @@ L.GeoSearch.Provider.OpenStreetMap = L.Class.extend({
     },
 
     ParseJSON: function (data) {
-        if (data.length == 0)
-            return [];
-
         var results = [];
-        for (var i = 0; i < data.length; i++) 
+
+        for (var i = 0; i < data.length; i++) {
+            var boundingBox = data[i].boundingbox,
+                northEastLatLng = new L.LatLng( boundingBox[1], boundingBox[3] ),
+                southWestLatLng = new L.LatLng( boundingBox[0], boundingBox[2] );
+
             results.push(new L.GeoSearch.Result(
-                data[i].lon, 
-                data[i].lat, 
+                data[i].lon,
+                data[i].lat,
                 data[i].display_name,
-                null,
+                new L.LatLngBounds([
+                    northEastLatLng,
+                    southWestLatLng
+                ]),
                 data[i].address
             ));
-        
+        }
+
         return results;
     }
 });

--- a/src/js/l.geosearch.provider.openstreetmap.js
+++ b/src/js/l.geosearch.provider.openstreetmap.js
@@ -33,7 +33,9 @@ L.GeoSearch.Provider.OpenStreetMap = L.Class.extend({
             results.push(new L.GeoSearch.Result(
                 data[i].lon, 
                 data[i].lat, 
-                data[i].display_name
+                data[i].display_name,
+                null,
+                data[i].address
             ));
         
         return results;


### PR DESCRIPTION
### Address details
With OSM by passing `{addressdetails: 1}` when initializing the provider, you can get back specific details on the different elements of the result address (like postal code etc).

This change exposes those details to the end dev in the `details` property of search result's `Location`. I only took the time to implement this for OSM for now, maybe others can help by doing the same for other providers.

### Bounds
I'm also constructing bounds to be passed back to the map. 