### PR TITLE
Returns valid map property (_zoom). Fixes #65

### DIFF
--- a/src/js/l.control.geosearch.js
+++ b/src/js/l.control.geosearch.js
@@ -238,7 +238,7 @@ L.Control.GeoSearch = L.Control.extend({
         if (! this.options.retainZoomLevel) {
             return this._config.zoomLevel;
         }
-        return this._map.zoom;
+        return this._map._zoom;
     }
 
 });


### PR DESCRIPTION
- When 'retainZoomLevel' is set to true, _getZoomLevel returns zoom of map.
- Whereas there is no such property as 'zoom' for map and hence undefined is returned.
- Correct property is '_zoom' which should be returned to make zoom work fine when retainZoomLevel is set to true.
- Refer the Leaflet source code (getZoom function).