### PR TITLE
show a popup after a search is completed successfully

### DIFF
--- a/src/js/l.control.geosearch.js
+++ b/src/js/l.control.geosearch.js
@@ -20,6 +20,7 @@ L.Control.GeoSearch = L.Control.extend({
     options: {
         position: 'topcenter',
         showMarker: true,
+        customIcon: false,
         retainZoomLevel: false,
         draggable: false
     },
@@ -189,6 +190,9 @@ L.Control.GeoSearch = L.Control.extend({
                     [location.Y, location.X],
                     {draggable: this.options.draggable}
                 ).addTo(this._map);
+                if( this.options.customIcon ) {
+                    this._positionMarker.setIcon(this.options.customIcon);
+                }
             }
             else {
                 this._positionMarker.setLatLng([location.Y, location.X]);

--- a/src/js/l.control.geosearch.js
+++ b/src/js/l.control.geosearch.js
@@ -20,6 +20,7 @@ L.Control.GeoSearch = L.Control.extend({
     options: {
         position: 'topcenter',
         showMarker: true,
+        showPopup: false,
         customIcon: false,
         retainZoomLevel: false,
         draggable: false
@@ -95,13 +96,13 @@ L.Control.GeoSearch = L.Control.extend({
             var provider = this._config.provider;
 
             if(typeof provider.GetLocations == 'function') {
-                var results = provider.GetLocations(qry, function(results) {
-                    that._processResults(results);
+                provider.GetLocations(qry, function(results) {
+                    that._processResults(results, qry);
                 });
             }
             else {
                 var url = provider.GetServiceUrl(qry);
-                this.sendRequest(provider, url);
+                this.sendRequest(provider, url, qry);
             }
         }
         catch (error) {
@@ -109,12 +110,12 @@ L.Control.GeoSearch = L.Control.extend({
         }
     },
 
-    sendRequest: function (provider, url) {
+    sendRequest: function (provider, url, qry) {
         var that = this;
 
         window.parseLocation = function (response) {
             var results = provider.ParseJSON(response);
-            that._processResults(results);
+            that._processResults(results, qry);
 
             document.body.removeChild(document.getElementById('getJsonP'));
             delete window.parseLocation;
@@ -141,7 +142,7 @@ L.Control.GeoSearch = L.Control.extend({
                             var response = JSON.parse(xhr.responseText),
                                 results = provider.ParseJSON(response);
 
-                            that._processResults(results);
+                            that._processResults(results, qry);
                         } else if (xhr.status == 0 || xhr.status == 400) {
                             getJsonP(url);
                         } else {
@@ -163,7 +164,7 @@ L.Control.GeoSearch = L.Control.extend({
                     var response = JSON.parse(xdr.responseText),
                         results = provider.ParseJSON(response);
 
-                    that._processResults(results);
+                    that._processResults(results, qry);
                 };
 
                 xdr.open('GET', url);
@@ -174,16 +175,16 @@ L.Control.GeoSearch = L.Control.extend({
         }
     },
 
-    _processResults: function(results) {
+    _processResults: function(results, qry) {
         if (results.length > 0) {
             this._map.fireEvent('geosearch_foundlocations', {Locations: results});
-            this._showLocation(results[0]);
+            this._showLocation(results[0], qry);
         } else {
             this._printError(this._config.notFoundMessage);
         }
     },
 
-    _showLocation: function (location) {
+    _showLocation: function (location, qry) {
         if (this.options.showMarker == true) {
             if (typeof this._positionMarker === 'undefined') {
                 this._positionMarker = L.marker(
@@ -193,9 +194,15 @@ L.Control.GeoSearch = L.Control.extend({
                 if( this.options.customIcon ) {
                     this._positionMarker.setIcon(this.options.customIcon);
                 }
+                if( this.options.showPopup ) {
+                   this._positionMarker.bindPopup(qry).openPopup();
+                }
             }
             else {
                 this._positionMarker.setLatLng([location.Y, location.X]);
+                if( this.options.showPopup ) {
+                   this._positionMarker.bindPopup(qry).openPopup();
+                }
             }
         }
         if (!this.options.retainZoomLevel && location.bounds && location.bounds.isValid()) {


### PR DESCRIPTION
This pull request is based on #64 (and thus closes #64 if accepted).

It also adds a new option `showPopup` (`false` by default). If it is set to `true`, then after each successful search a popup appears above the resulting marker; that popup contains a copy of the search query.

If there are many markers on the map, such popup helps users to identify search results. (It might be quite useful to change the results' marker as well, and that's exactly why this pull request is based on #64.)