### PR TITLE
Fix other non-http protocal issue

### DIFF
--- a/src/js/l.geosearch.provider.openstreetmap.js
+++ b/src/js/l.geosearch.provider.openstreetmap.js
@@ -17,7 +17,7 @@ L.GeoSearch.Provider.OpenStreetMap = L.Class.extend({
             format: 'json'
         }, this.options);
 
-        return (location.protocol === 'https:' ? 'https:' : 'http:')
+        return (~location.protocol.indexOf('http') ? location.protocol : 'https:')
             + '//nominatim.openstreetmap.org/search'
             + L.Util.getParamString(parameters);
     },


### PR DESCRIPTION
I use this plugin with Ionic framework, it's hybrid app and the location.protocal is 'file:'.
This will cause http request fail.